### PR TITLE
fix(llm): LLM-first responses with explicit non-LLM fallback

### DIFF
--- a/core/agents/user_interact/user_interaction_agent.py
+++ b/core/agents/user_interact/user_interaction_agent.py
@@ -5,6 +5,12 @@ from dotenv import load_dotenv
 # Load .env variables
 load_dotenv()
 
+# Optional LLM helper
+try:
+    from app.llm_client import get_llm_client
+except Exception:
+    get_llm_client = None
+
 class UserInteractionAgent:
     def __init__(self, user_name):
         self.user_name = user_name
@@ -27,28 +33,57 @@ class UserInteractionAgent:
         self.memory.append({"role": role, "content": content})
 
     def get_response(self, message):
-        if not self.is_dynamic_pricing_related(message):
-            return "I'm only able to respond to queries related to the dynamic pricing system."
+        """Return an LLM-powered response for any query when available.
+
+        Behavior:
+        - If an LLM client is available, forward the message (with memory/system prompt) and return the model answer.
+        - If LLM is not available, keep the original keyword guard but return an explicit non-LLM fallback message so callers know it's not the LLM speaking.
+        """
 
         # Add user message to memory
         self.add_to_memory("user", message)
 
+        # Build system prompt focused on dynamic pricing
+        system_prompt = (
+            f"You are a specialized assistant for the dynamic pricing system. "
+            f"Only provide responses related to pricing strategies, discounts, "
+            f"offers, demand/supply, and related financial metrics."
+        )
+
+        # Attempt to use LLM client if available
+        try:
+            if get_llm_client is not None:
+                llm = get_llm_client()
+                if llm.is_available():
+                    msgs = [{"role": "system", "content": system_prompt}]
+                    msgs.extend(self.memory)
+                    msgs.append({"role": "user", "content": message})
+                    try:
+                        answer = llm.chat(msgs)
+                        # Add assistant reply to memory
+                        self.add_to_memory("assistant", answer)
+                        return answer
+                    except Exception as e:
+                        # Fall through to explicit non-LLM fallback
+                        pass
+
+        except Exception:
+            # Any error while attempting LLM shouldn't crash; we'll fall back
+            pass
+
+        # LLM not available or failed. Use keyword guard to determine messaging; but mark as non-LLM.
+        if not self.is_dynamic_pricing_related(message):
+            return "[non-LLM assistant] I'm only able to respond to queries related to the dynamic pricing system."
+
+        # As a last resort, attempt the previous direct HTTP OpenRouter path (preserves compatibility)
         try:
             headers = {
                 "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
             }
 
-            # Include memory in the system messages
-            messages = [{"role": "system", "content": (
-                f"You are a specialized assistant for the dynamic pricing system. "
-                f"Only provide responses related to pricing strategies, discounts, "
-                f"offers, demand/supply, and related financial metrics."
-            )}]
-            # Append previous conversation from memory
+            messages = [{"role": "system", "content": system_prompt}]
             messages.extend(self.memory)
-
-            # Current user message
             messages.append({"role": "user", "content": message})
 
             data = {
@@ -64,11 +99,10 @@ class UserInteractionAgent:
 
             if response.status_code == 200:
                 answer = response.json()["choices"][0]["message"]["content"]
-                # Add bot response to memory
                 self.add_to_memory("assistant", answer)
                 return answer
             else:
-                return f"Error {response.status_code}: {response.text}"
+                return f"[non-LLM assistant] Error {response.status_code}: {response.text}"
 
         except Exception as e:
-            return f"Exception: {str(e)}"
+            return f"[non-LLM assistant] Exception: {str(e)}"


### PR DESCRIPTION
Try LLM for all user messages; when LLM is not available return an explicit '[non-LLM assistant]' fallback. This PR includes only the changes to core/agents/user_interact/user_interaction_agent.py.